### PR TITLE
attempt to fix argument error

### DIFF
--- a/lib/stash.ex
+++ b/lib/stash.ex
@@ -252,7 +252,7 @@ defmodule Stash do
 
   """
   @spec persist(atom, binary) :: atom
-  deft persist(cache, path) when is_binary(path) do
+  deft persist(cache, path) do
     case :dets.open_file(path, gen_dts_args(cache)) do
       { :ok, ^path } ->
         :dets.from_ets(path, cache)


### PR DESCRIPTION
** (ArgumentError) argument error
    (stdlib) dets.erl:658: :dets.open_file("/tmp/temporary.dat", [keypos: 1, type: :set])
    lib/stash.ex:251: Stash.persist/2